### PR TITLE
Fix mapping between screen orientations and rotation angles.

### DIFF
--- a/input-context/minputcontext.cpp
+++ b/input-context/minputcontext.cpp
@@ -25,6 +25,7 @@
 #include <QDebug>
 #include <QByteArray>
 #include <QRectF>
+#include <QScreen>
 #include <QLocale>
 #include <QWindow>
 #include <QSharedDataPointer>
@@ -37,22 +38,8 @@ namespace
 
     int orientationAngle(Qt::ScreenOrientation orientation)
     {
-        // Maliit uses orientations relative to screen, Qt relative to world
-        // Note: doesn't work with inverted portrait or landscape as native screen orientation.
-        static bool portraitRotated = qGuiApp->primaryScreen()->primaryOrientation() == Qt::PortraitOrientation;
-
-        switch (orientation) {
-        case Qt::PrimaryOrientation: // Urgh.
-        case Qt::PortraitOrientation:
-            return portraitRotated ? MInputContext::Angle0 : MInputContext::Angle270;
-        case Qt::LandscapeOrientation:
-            return portraitRotated ? MInputContext::Angle90 : MInputContext::Angle0;
-        case Qt::InvertedPortraitOrientation:
-            return portraitRotated ? MInputContext::Angle180 : MInputContext::Angle90;
-        case Qt::InvertedLandscapeOrientation:
-            return portraitRotated ? MInputContext::Angle270 : MInputContext::Angle180;
-        }
-        return MInputContext::Angle0;
+        QScreen *screen = qGuiApp->primaryScreen();
+        return screen->angleBetween(screen->primaryOrientation(), orientation);
     }
 }
 


### PR DESCRIPTION
The existing mapping between Qt::ScreenOrientation values and rotation angles is wrong.
This patch fixes it by simply using the existing function for this from Qt.

E.g.:
If primary angle is Landscape and the given orientation is Portrait, the resulting rotation angle is 90, not 270 as in that switch. Documentation for Qt::PortraitOrientation says it is " rotated 90 degree clockwise relative to landscape."
