### PR TITLE
stop passing non-existing arguments to the maliit server from example app

### DIFF
--- a/examples/apps/plainqt/mainwindow.cpp
+++ b/examples/apps/plainqt/mainwindow.cpp
@@ -173,19 +173,10 @@ bool MainWindow::eventFilter(QObject *watched,
 
 void MainWindow::onStartServerClicked()
 {
-
-    QStringList arguments;
-    arguments << "-bypass-wm-hint";
-
-    // Self-compositing is currently only supported in fullscreen mode:
-    if (enableFullScreenMode()) {
-        arguments << "-use-self-composition";
-    }
-
     if (m_server_process->state() != QProcess::NotRunning) {
         m_server_process->terminate();
     } else {
-        m_server_process->start(serverName, arguments);
+        m_server_process->start(serverName, QStringList());
     }
 }
 


### PR DESCRIPTION
it seems like the command line arguments this example app has been removed from the server.