### PR TITLE
Clear preedit state on input context reset

### DIFF
--- a/input-context/minputcontext.cpp
+++ b/input-context/minputcontext.cpp
@@ -160,6 +160,8 @@ void MInputContext::reset()
     if (debug) qDebug() << InputContextName << "in" << __PRETTY_FUNCTION__;
 
     const bool hadPreedit = !preedit.isEmpty();
+    preedit.clear();
+    preeditCursorPos = -1;
 
     // reset input method server, preedit requires synchronization.
     // rationale: input method might be autocommitting existing preedit without


### PR DESCRIPTION
On rare case wrong preedit was committed, e.g:
- while preedit existed, the application programmatically changed editor
content -> reset()
- focus removed from editor -> commit()