### PR TITLE
Replace hard coded string with QPlatformInputContextFactoryInterface_iid

### DIFF
--- a/input-context/main.cpp
+++ b/input-context/main.cpp
@@ -22,7 +22,7 @@
 class MaliitPlatformInputContextPlugin: public QPlatformInputContextPlugin
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QPlatformInputContextFactoryInterface" FILE "maliit.json")
+    Q_PLUGIN_METADATA(IID QPlatformInputContextFactoryInterface_iid FILE "maliit.json")
 
 public:
     QPlatformInputContext *create(const QString&, const QStringList&);


### PR DESCRIPTION
The fixes compatibility with Qt 5.5 where this string has changed, as detailed in issue #13 