### PR TITLE
Redeclare input_method_activate for wayland to match the generated we…

### DIFF
--- a/connection/waylandinputmethodconnection.cpp
+++ b/connection/waylandinputmethodconnection.cpp
@@ -156,7 +156,7 @@ public:
     InputMethodContext *context() const;
 
 protected:
-    void input_method_activate(struct ::wl_input_method *object, struct ::wl_input_method_context *id) Q_DECL_OVERRIDE;
+    void input_method_activate(struct ::wl_input_method_context *id) Q_DECL_OVERRIDE;
     void input_method_deactivate(struct ::wl_input_method_context *context) Q_DECL_OVERRIDE;
 
 private:
@@ -484,7 +484,7 @@ InputMethodContext *InputMethod::context() const
     return m_context.data();
 }
 
-void InputMethod::input_method_activate(struct ::wl_input_method *, struct ::wl_input_method_context *id)
+void InputMethod::input_method_activate(struct ::wl_input_method_context *id)
 {
     qDebug() << Q_FUNC_INFO;
 


### PR DESCRIPTION
Redeclare *input_method_activate* for wayland to match the generated weston protocols of qwayland input method

Without this change, the input method cannot be activated and Maliit keyboard cannot popup in Weston

The generated file *qwayland-input-method.cpp* in *weston-protocols* defines the activate handler like this ( no the first parameter *object*, only *id* ):
<pre><code>    void wl_input_method::handle_activate(
        void *data,
        struct ::wl_input_method *object,
        struct ::wl_input_method_context *id)
    {
        Q_UNUSED(object);
        static_cast<wl_input_method *>(data)->input_method_activate(
            id);
    }
</code></pre>

**Build Environment**:
Host: Ubuntu 14.04 x64/
Target: TI Jacinto 6/Linux/Qt 5.5.0/Wayland 1.5
Toolchain: glsdk 6.10/gcc-linaro-arm-linux-gnueabihf-4.7-2013.03-20130313_linux
