### PR TITLE
Don't require unref from GDBusProxy helpers

### DIFF
--- a/maliit-glib/maliitattributeextensionregistry.c
+++ b/maliit-glib/maliitattributeextensionregistry.c
@@ -173,7 +173,6 @@ connection_established (GObject      *source_object G_GNUC_UNUSED,
 
     if (server) {
         register_all_extensions (server, user_data);
-        g_object_unref (server);
     } else {
         g_warning ("Unable to connect to server: %s", error->message);
         g_clear_error (&error);
@@ -239,8 +238,6 @@ maliit_attribute_extension_registry_add_extension (MaliitAttributeExtensionRegis
                 g_warning ("Unable to register extension: %s", error->message);
                 g_clear_error (&error);
             }
-
-            g_object_unref (server);
         } else {
             g_warning ("Unable to connect to server: %s", error->message);
             g_clear_error (&error);
@@ -277,8 +274,6 @@ maliit_attribute_extension_registry_remove_extension (MaliitAttributeExtensionRe
                 g_warning ("Unable to unregister extension: %s", error->message);
                 g_clear_error (&error);
             }
-
-            g_object_unref (server);
         } else {
             g_warning ("Unable to connect to server: %s", error->message);
             g_clear_error (&error);
@@ -328,8 +323,6 @@ maliit_attribute_extension_registry_extension_changed (MaliitAttributeExtensionR
                 g_warning ("Unable to set extended attribute: %s", error->message);
                 g_clear_error (&error);
             }
-
-            g_object_unref (server);
         } else {
             g_warning ("Unable to connect to server: %s", error->message);
             g_clear_error (&error);

--- a/maliit-glib/maliitinputmethod.c
+++ b/maliit-glib/maliitinputmethod.c
@@ -70,7 +70,6 @@ maliit_input_method_dispose (GObject *object)
 
     if (context) {
         g_signal_handlers_disconnect_by_data (context, input_method);
-        g_object_unref (context);
     } else {
         g_warning ("Unable to connect to context: %s", error->message);
         g_clear_error (&error);
@@ -149,7 +148,9 @@ maliit_input_method_init (MaliitInputMethod *input_method)
 
     priv->maliit_proxy = maliit_get_server_sync (NULL, &error);
 
-    if (!priv->maliit_proxy) {
+    if (priv->maliit_proxy) {
+        g_object_ref (priv->maliit_proxy);
+    } else {
         g_warning ("Unable to connect to server: %s", error->message);
         g_clear_error (&error);
     }
@@ -163,7 +164,6 @@ maliit_input_method_init (MaliitInputMethod *input_method)
                                   "handle-update-input-method-area",
                                   G_CALLBACK (update_input_method_area),
                                   input_method);
-        g_object_unref (context);
     } else {
         g_warning ("Unable to connect to context: %s", error->message);
         g_clear_error (&error);

--- a/maliit-glib/maliitsettingsmanager.c
+++ b/maliit-glib/maliitsettingsmanager.c
@@ -74,7 +74,6 @@ maliit_settings_manager_dispose (GObject *object)
 
     if (context) {
         g_signal_handlers_disconnect_by_data (context, manager);
-        g_object_unref (context);
     } else {
         g_warning ("Unable to connect to context: %s", error->message);
         g_clear_error (&error);
@@ -247,7 +246,6 @@ connection_established (GObject      *source_object G_GNUC_UNUSED,
 
     if (server) {
         on_connection_established (user_data, server);
-        g_object_unref (server);
     } else {
         g_warning ("Unable to connect to server: %s", error->message);
         g_clear_error (&error);
@@ -276,8 +274,6 @@ maliit_settings_manager_init (MaliitSettingsManager *manager)
                                   "handle-plugin-settings-loaded",
                                   G_CALLBACK (on_plugins_loaded),
                                   manager);
-
-        g_object_unref (context);
     } else {
         g_warning ("Unable to connect to context: %s", error->message);
         g_clear_error (&error);
@@ -324,8 +320,6 @@ maliit_settings_manager_load_plugin_settings (MaliitSettingsManager *manager)
             g_warning ("Unable to load plugin settings: %s", error->message);
             g_clear_error (&error);
         }
-
-        g_object_unref (server);
     } else {
         g_warning ("Unable to connect to server: %s", error->message);
         g_clear_error (&error);


### PR DESCRIPTION
We should make these transfer-none (i.e. make the caller ref them explicitly). It's more conventional with the names we've given them (get vs new).