### PR TITLE
Fix broken tests

### DIFF
--- a/src/mimsettingsqsettings.cpp
+++ b/src/mimsettingsqsettings.cpp
@@ -105,6 +105,7 @@ void MImSettingsQSettingsBackend::set(const QVariant &val)
         return;
 
     d->settingsInstance->setValue(d->key, val);
+    d->settingsInstance->sync();
     d->notify();
 }
 
@@ -116,6 +117,7 @@ void MImSettingsQSettingsBackend::unset()
         return;
 
     d->settingsInstance->remove(d->key);
+    d->settingsInstance->sync();
     d->notify();
 }
 

--- a/tests/ut_mimonscreenplugins/ut_mimonscreenplugins.cpp
+++ b/tests/ut_mimonscreenplugins/ut_mimonscreenplugins.cpp
@@ -23,38 +23,23 @@
 namespace
 {
 
-const QString Organization = "maliit.org";
-const QString Application = "server-tests";
 const QString DefaultPlugin = MALIIT_DEFAULT_PLUGIN;
 
 }
 
 void Ut_MImOnScreenPlugins::initTestCase()
 {
-    MImSettings::setImplementationFactory(new MImSettingsQSettingsBackendFactory(Organization, Application));
-
-    // Make sure we start with empty/non-existing config file:
-    QSettings settings(Organization, Application);
-    QFile file(settings.fileName());
-    file.remove();
+    MImSettings::setPreferredSettingsType(MImSettings::TemporarySettings);
 }
 
 void Ut_MImOnScreenPlugins::cleanupTestCase()
-{
-    // Make sure we remove the config file at the end, too:
-    QSettings settings(Organization, Application);
-    QFile file(settings.fileName());
-    file.remove();
-}
+{}
 
 void Ut_MImOnScreenPlugins::init()
 {}
 
 void Ut_MImOnScreenPlugins::cleanup()
-{
-    QSettings settings(Organization, Application);
-    settings.clear();
-}
+{}
 
 void Ut_MImOnScreenPlugins::testActiveAndEnabledSubviews_data()
 {
@@ -102,14 +87,15 @@ void Ut_MImOnScreenPlugins::testActiveAndEnabledSubviews()
     QFETCH(int, expected_enabled_count);
     QFETCH(int, expected_active_index);
 
-    QSettings settings(Organization, Application);
+    MImSettings activeSetting(active_key);
+    MImSettings enabledSetting(enabled_key);
 
     if (not initially_active.isEmpty()) {
-        settings.setValue(active_key, initially_active);
+        activeSetting.set(initially_active);
     }
 
     if (not initially_enabled.isEmpty()) {
-        settings.setValue(enabled_key, initially_enabled);
+        enabledSetting.set(initially_enabled);
     }
 
     MImOnScreenPlugins plugins;

--- a/tests/ut_mimpluginmanagerconfig/ut_mimpluginmanagerconfig.cpp
+++ b/tests/ut_mimpluginmanagerconfig/ut_mimpluginmanagerconfig.cpp
@@ -46,9 +46,6 @@ Q_DECLARE_METATYPE(HandlerStates);
 Q_DECLARE_METATYPE(Maliit::HandlerState);
 
 namespace {
-    const QString Organization = "maliit.org";
-    const QString Application = "server-tests";
-
     const QString ConfigRoot = MALIIT_CONFIG_ROOT;
     const QString MImPluginPaths = ConfigRoot + "paths";
 
@@ -73,20 +70,10 @@ namespace {
 void Ut_MIMPluginManagerConfig::initTestCase()
 {
     MImSettings::setPreferredSettingsType(MImSettings::TemporarySettings);
-    MImSettings::setImplementationFactory(new MImSettingsQSettingsBackendFactory(Organization, Application));
-
-    // Make sure we start with empty/non-existing config file:
-    QSettings settings(Organization, Application);
-    QFile file(settings.fileName());
-    file.remove();
 }
  
 void Ut_MIMPluginManagerConfig::cleanupTestCase()
 {
-    // Make sure we remove the config file at the end, too:
-    QSettings settings(Organization, Application);
-    QFile file(settings.fileName());
-    file.remove();
 }
 
 void Ut_MIMPluginManagerConfig::init()


### PR DESCRIPTION
Some of the tests weren't working because either the QSettings changes weren't being flushed to disk, or the tests were actually reading settings from the builder's existing configuration.