### PR TITLE
Revert "Move GDBus code generation to maliit-glib"

### DIFF
--- a/dbus_interfaces/dbus_interfaces.pro
+++ b/dbus_interfaces/dbus_interfaces.pro
@@ -9,3 +9,22 @@ TARGET = dummy
 OTHER_FILES += \
     minputmethodcontext1interface.xml \
     minputmethodserver1interface.xml
+
+glib {
+    include($$TOP_DIR/dbus_interfaces/dbus_interfaces.pri)
+
+    PRE_TARGETDEPS += glib_server glib_context
+    QMAKE_EXTRA_TARGETS += glib_server glib_context
+
+    glib_server.commands = gdbus-codegen --interface-prefix com.meego \
+                                         --generate-c-code $$TOP_DIR/maliit-glib/maliitserver \
+                                         --c-namespace Maliit \
+                                         --annotate com.meego.inputmethod.uiserver1 org.gtk.GDBus.C.Name Server \
+                                         $$DBUS_SERVER_XML
+
+    glib_context.commands = gdbus-codegen --interface-prefix com.meego \
+                                          --generate-c-code $$TOP_DIR/maliit-glib/maliitcontext \
+                                          --c-namespace Maliit \
+                                          --annotate com.meego.inputmethod.inputcontext1 org.gtk.GDBus.C.Name Context \
+                                          $$DBUS_CONTEXT_XML
+}

--- a/maliit-glib/maliit-glib.pro
+++ b/maliit-glib/maliit-glib.pro
@@ -11,6 +11,8 @@ PKGCONFIG += glib-2.0 gobject-2.0 gio-2.0 gio-unix-2.0
 
 CONFIG -= qt
 
+include($$TOP_DIR/connection-glib/libmaliit-connection-glib.pri)
+
 QMAKE_CXXFLAGS_DEBUG+=-Wno-error=deprecated-declarations
 QMAKE_CFLAGS_DEBUG+=-Wno-error=deprecated-declarations
 
@@ -98,21 +100,3 @@ glib_genmarshal_source.variable_out = SOURCES
 glib_genmarshal_source.input = GLIB_GENMARSHAL_LIST
 
 QMAKE_EXTRA_COMPILERS += glib_genmarshal_header glib_genmarshal_source
-
-include($$TOP_DIR/dbus_interfaces/dbus_interfaces.pri)
-
-PRE_TARGETDEPS += glib_server glib_context
-QMAKE_EXTRA_TARGETS += glib_server glib_context
-
-glib_server.commands = gdbus-codegen --interface-prefix com.meego \
-                                     --generate-c-code $$TOP_DIR/maliit-glib/maliitserver \
-                                     --c-namespace Maliit \
-                                     --annotate com.meego.inputmethod.uiserver1 org.gtk.GDBus.C.Name Server \
-                                     $$DBUS_SERVER_XML
-
-glib_context.commands = gdbus-codegen --interface-prefix com.meego \
-                                      --generate-c-code $$TOP_DIR/maliit-glib/maliitcontext \
-                                      --c-namespace Maliit \
-                                      --annotate com.meego.inputmethod.inputcontext1 org.gtk.GDBus.C.Name Context \
-                                      $$DBUS_CONTEXT_XML
-


### PR DESCRIPTION
This reverts commit 6e2f8b4253f219688d31002aebf010eeabf0079b.

The previous commit caused a regression where the generated headers maliitserver.h and maliitcontext.h would no longer be installed on 'make install'. The problem is due to how QMake works: it processes the list of HEADERSINSTALL before generating them via the glib_server and glib_context targets.