### PR TITLE
Fix ld failed when build passthroughserver

### DIFF
--- a/src/mimhwkeyboardtracker.cpp
+++ b/src/mimhwkeyboardtracker.cpp
@@ -18,7 +18,13 @@
 
 #include <QSocketNotifier>
 
+#ifdef __cplusplus
+extern "C" {
 #include <libudev.h>
+}
+#else
+#include <libudev.h>
+#endif
 #include <linux/input.h>
 
 #include "mimhwkeyboardtracker.h"


### PR DESCRIPTION
error massage:

arm-none-linux-gnueabi-g++ --sysroot=/scratchbox/users/zhang/targets/HARMATTAN_ARMEL -Wl,-O1 -Wl,--as-needed -Wl,-rpath,/opt/qt5.5.1/lib -o maliit-server .obj/main.o   ../lib/libmaliit-plugins.so ../lib/libmaliit-common.a ../lib/libmaliit-connection.a -L/scratchbox/users/zhang/targets/HARMATTAN_ARMEL/opt/qt5.5.1/lib -lQt5Gui -lQt5DBus -lQt5Core -lGLESv2 -lpthread 
../lib/libmaliit-plugins.so: to‘udev_enumerate_new(udev_)’ undefined reference
../lib/libmaliit-plugins.so: to‘udev_enumerate_get_list_entry(udev_enumerate_)’undefined reference
.....................
collect2: error: ld returned 1 exit status
