### PR TITLE
Need to allow the qt input context dbus server address to be overridden

### DIFF
--- a/input-context/minputcontext.cpp
+++ b/input-context/minputcontext.cpp
@@ -73,9 +73,17 @@ MInputContext::MInputContext()
         debug = true;
     }
 
-    QSharedPointer<Maliit::InputContext::DBus::Address> address(new Maliit::InputContext::DBus::DynamicAddress);
-    imServer = new DBusServerConnection(address);
+    QSharedPointer<Maliit::InputContext::DBus::Address> address;
 
+    QByteArray maliitServerAddress = qgetenv("MALIIT_SERVER_ADDRESS");
+    if (!maliitServerAddress.isEmpty()) {
+        address.reset(new Maliit::InputContext::DBus::FixedAddress(maliitServerAddress.constData()));
+    } else {
+        address.reset(new Maliit::InputContext::DBus::DynamicAddress);
+    }
+
+    imServer = new DBusServerConnection(address);
+    
     sipHideTimer.setSingleShot(true);
     sipHideTimer.setInterval(SoftwareInputPanelHideTimer);
     connect(&sipHideTimer, SIGNAL(timeout()), SLOT(sendHideInputMethod()));


### PR DESCRIPTION
Just like in maliit-glib, we should check if the MALIIT_SERVER_ADDRESS has been set. This way we use that dbus address.

A use case here, is when we create a proxy socket for the clients to read/write from while the maliit server still uses the original abstract socket. This way we can create a real socket for it to be bind mounted over an lxc container and the applications in the lxc container can still use the host maliit server.

Doing this works find for gtk since maliit-glib checks this env. As for qt it does not, and assumes the abstract location.