### PR TITLE
Add envar to force a dbus input context connection

### DIFF
--- a/passthroughserver/main.cpp
+++ b/passthroughserver/main.cpp
@@ -87,7 +87,8 @@ void outputMessagesToStdErr(QtMsgType type,
 QSharedPointer<MInputContextConnection> createConnection(const MImServerConnectionOptions &options)
 {
 #ifdef HAVE_WAYLAND
-    if (QGuiApplication::platformName().startsWith("wayland")) {
+    auto forceDbus = qgetenv("MALIIT_FORCE_DBUS_CONNECTION");
+    if (QGuiApplication::platformName().startsWith("wayland") && (forceDbus.isEmpty() || forceDbus == "0")) {
         return QSharedPointer<MInputContextConnection>(Maliit::createWestonIMProtocolConnection());
     } else
 #endif

--- a/src/maliit/standaloneinputmethod.cpp
+++ b/src/maliit/standaloneinputmethod.cpp
@@ -130,13 +130,13 @@ void StandaloneInputMethod::handleWidgetStateChanged(unsigned int,
 std::unique_ptr<MInputContextConnection> createConnection()
 {
 #ifdef HAVE_WAYLAND
-    if (QGuiApplication::platformName().startsWith("wayland")) {
+    auto forceDbus = qgetenv("MALIIT_FORCE_DBUS_CONNECTION");
+    if (QGuiApplication::platformName().startsWith("wayland") && (forceDbus.isEmpty() || forceDbus == "0")) {
         return std::unique_ptr<MInputContextConnection>(Maliit::createWestonIMProtocolConnection());
     } else
 #endif
         return std::unique_ptr<MInputContextConnection>(Maliit::DBus::createInputContextConnectionWithDynamicAddress());
 
 }
-
 
 }


### PR DESCRIPTION
This adds the envar MALIIT_FORCE_DBUS_CONNECTION to allow maliit to
force use of a dbus type connections instead of wayland one.