### PR TITLE
Update input method area when hiding the keyboard

### DIFF
--- a/src/windowgroup.cpp
+++ b/src/windowgroup.cpp
@@ -105,9 +105,10 @@ void WindowGroup::setInputMethodArea(const QRegion &region, QWindow *window)
         }
     }
 
-    if (m_active) {
-        updateInputMethodArea();
-    }
+    // We should update the input method area regardless of whether we're still
+    // active or not, as keyboard hiding animations could be changing this
+    // region after we've deactivated
+    updateInputMethodArea();
 }
 
 void WindowGroup::setApplicationWindow(WId id)


### PR DESCRIPTION
This patch ensures that maliit continues to update the input method area
after the keyboard has been dismissed. This allows keyboard hiding
animations to provide a smooth transition between the showing and hiding
states.