### PR TITLE
Install input context in the right directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,7 +439,7 @@ if(enable-glib)
 endif()
 
 if(enable-qt5-inputcontext)
-    install(TARGETS maliitplatforminputcontextplugin LIBRARY DESTINATION ${QT5_PLUGINS_INSTALL_DIR}/platforminputcontext)
+    install(TARGETS maliitplatforminputcontextplugin LIBRARY DESTINATION ${QT5_PLUGINS_INSTALL_DIR}/platforminputcontexts)
 endif()
 
 if(enable-wayland)


### PR DESCRIPTION
It currently installs to [QT_PLUGIN_PATH]/platforminputcontext, this is incorrect, the correct path for qt is [QT_PLUGIN_PATH]/platforminputcontexts