### PR TITLE
Show the panel as the keyboard interface is reset

### DIFF
--- a/connection/waylandinputmethodconnection.cpp
+++ b/connection/waylandinputmethodconnection.cpp
@@ -568,6 +568,7 @@ void InputMethodContext::zwp_input_method_context_v1_reset()
     qCDebug(lcWaylandConnection) << Q_FUNC_INFO;
 
     m_connection->reset(wayland_connection_id);
+    m_connection->showInputMethod(wayland_connection_id);
 }
 
 void InputMethodContext::zwp_input_method_context_v1_surrounding_text(const QString &text, uint32_t cursor, uint32_t anchor)


### PR DESCRIPTION
This allows the compositor to show the panel again as the context
massively changes.