### PR TITLE
Pull in some of the patches from Ubuntu packaging

### DIFF
--- a/input-context/minputcontext.cpp
+++ b/input-context/minputcontext.cpp
@@ -430,7 +430,7 @@ void MInputContext::imInitiatedHide()
 
     // remove focus on QtQuick2
     QQuickItem *inputItem = qobject_cast<QQuickItem*>(QGuiApplication::focusObject());
-    if (inputItem) {
+    if (inputItem && inputItem->flags().testFlag(QQuickItem::ItemAcceptsInputMethod)) {
         inputItem->setFocus(false);
     }
 

--- a/input-context/minputcontext.cpp
+++ b/input-context/minputcontext.cpp
@@ -301,6 +301,9 @@ void MInputContext::setFocusObject(QObject *focused)
     if (!active && currentFocusAcceptsInput) {
         imServer->activateContext();
         active = true;
+    }
+
+    if (currentFocusAcceptsInput) {
         updateServerOrientation(newFocusWindow->contentOrientation());
     }
 


### PR DESCRIPTION
When using maliit-server and the dbus protocol for input method handling, as is done on Ubuntu Touch, there are a few problematic areas, which are solved by patches included in the Ubuntu packages of maliit framework. This pulls in a couple more that have not yet been merged upstream (and aren't in other PRs).