### PR TITLE
Pull in some of the Ubuntu Touch patches

### DIFF
--- a/input-context/minputcontext.cpp
+++ b/input-context/minputcontext.cpp
@@ -430,7 +430,7 @@ void MInputContext::imInitiatedHide()
 
     // remove focus on QtQuick2
     QQuickItem *inputItem = qobject_cast<QQuickItem*>(QGuiApplication::focusObject());
-    if (inputItem) {
+    if (inputItem && inputItem->flags().testFlag(QQuickItem::ItemAcceptsInputMethod)) {
         inputItem->setFocus(false);
     }
 

--- a/input-context/minputcontext.cpp
+++ b/input-context/minputcontext.cpp
@@ -301,6 +301,9 @@ void MInputContext::setFocusObject(QObject *focused)
     if (!active && currentFocusAcceptsInput) {
         imServer->activateContext();
         active = true;
+    }
+
+    if (currentFocusAcceptsInput) {
         updateServerOrientation(newFocusWindow->contentOrientation());
     }
 

--- a/input-context/minputcontext.cpp
+++ b/input-context/minputcontext.cpp
@@ -436,10 +436,14 @@ void MInputContext::sendHideInputMethod()
 
 void MInputContext::activationLostEvent()
 {
+    if (debug) qDebug() << InputContextName << "in" << __PRETTY_FUNCTION__;
+
     // This method is called when activation was gracefully lost.
     // There is similar cleaning up done in onDBusDisconnection.
     active = false;
     inputPanelState = InputPanelHidden;
+
+    updateInputMethodArea(QRect());
 }
 
 

--- a/input-context/minputcontext.cpp
+++ b/input-context/minputcontext.cpp
@@ -303,7 +303,7 @@ void MInputContext::setFocusObject(QObject *focused)
         active = true;
     }
 
-    if (currentFocusAcceptsInput) {
+    if (newFocusWindow && currentFocusAcceptsInput) {
         updateServerOrientation(newFocusWindow->contentOrientation());
     }
 
@@ -836,6 +836,9 @@ int MInputContext::cursorStartPosition(bool *valid)
 void MInputContext::updateInputMethodExtensions()
 {
     if (!inputMethodAccepted()) {
+        return;
+    }
+    if (!qGuiApp->focusObject()) {
         return;
     }
     if (debug) qDebug() << InputContextName << __PRETTY_FUNCTION__;

--- a/input-context/minputcontext.h
+++ b/input-context/minputcontext.h
@@ -146,6 +146,7 @@ private:
     bool redirectKeys; // redirect all hw key events to the input method or not
     QLocale inputLocale;
     bool currentFocusAcceptsInput;
+    QPlatformInputContext *composeInputContext;
 };
 
 #endif


### PR DESCRIPTION
When using maliit-server and the dbus protocol for input method handling, as is done on Ubuntu Touch, there are a few problematic areas, which are solved by patches included in the Ubuntu/UBports packages of maliit framework. This pulls in a couple more that have not yet been merged upstream (and aren't in other PRs).