### PR TITLE
input_method_v1: Treat content_purpose_digits just like content_purpose_number

### DIFF
--- a/connection/waylandinputmethodconnection.cpp
+++ b/connection/waylandinputmethodconnection.cpp
@@ -121,6 +121,7 @@ Maliit::TextContentType contentTypeFromWayland(uint32_t purpose)
     switch (purpose) {
     case QtWayland::zwp_text_input_v1::content_purpose_normal:
         return Maliit::FreeTextContentType;
+    case QtWayland::zwp_text_input_v1::content_purpose_digits:
     case QtWayland::zwp_text_input_v1::content_purpose_number:
         return Maliit::NumberContentType;
     case QtWayland::zwp_text_input_v1::content_purpose_phone:


### PR DESCRIPTION
It's somewhat what's expected. The alternative is getting a full keyboard after all.