### PR TITLE
Fix installing README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,7 +416,7 @@ install(EXPORT MaliitPluginsTargets FILE MaliitPluginsTargets.cmake DESTINATION 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/MaliitPluginsConfig.cmake ${CMAKE_CURRENT_BINARY_DIR}/MaliitPluginsConfigVersion.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MaliitPlugins)
 
-install(FILES INSTALL.local LICENSE.LGPL NEWS README
+install(FILES INSTALL.local LICENSE.LGPL NEWS README.md
         DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/maliit-framework)
 
 if(enable-glib)


### PR DESCRIPTION
c76426d262 renamed the README to README.md, but this change was never
reflected in CMakeLists.txt, thus the install target would fail.

Unrelated, but why are the README and NEWS file being installed at all? And even the LICENSE file tbh, they don't seem to belong in a doc directory on the system.