### PR TITLE
Fix sending of modifiers and keysyms on Wayland

### DIFF
--- a/connection/waylandinputmethodconnection.cpp
+++ b/connection/waylandinputmethodconnection.cpp
@@ -80,10 +80,18 @@ xkb_mod_mask_t modifiersFromQt(const Qt::KeyboardModifiers qt_mods)
 xkb_keysym_t keyFromQt(int qt_key)
 {
     switch (qt_key) {
+    case Qt::Key_Escape:
+        return XKB_KEY_Escape;
+    case Qt::Key_Tab:
+        return XKB_KEY_Tab;
     case Qt::Key_Backspace:
         return XKB_KEY_BackSpace;
     case Qt::Key_Return:
         return XKB_KEY_Return;
+    case Qt::Key_Home:
+        return XKB_KEY_Home;
+    case Qt::Key_End:
+        return XKB_KEY_End;
     case Qt::Key_Left:
         return XKB_KEY_Left;
     case Qt::Key_Up:
@@ -92,7 +100,14 @@ xkb_keysym_t keyFromQt(int qt_key)
         return XKB_KEY_Right;
     case Qt::Key_Down:
         return XKB_KEY_Down;
+    case Qt::Key_PageUp:
+        return XKB_KEY_Prior;
+    case Qt::Key_PageDown:
+        return XKB_KEY_Next;
     default:
+        if (qt_key >= Qt::Key_Space && qt_key <= Qt::Key_ydiaeresis) {
+            return qt_key;
+        }
         return XKB_KEY_NoSymbol;
     }
 }

--- a/connection/waylandinputmethodconnection.cpp
+++ b/connection/waylandinputmethodconnection.cpp
@@ -56,6 +56,7 @@ QByteArray modifiersMap()
     QByteArray mod_map;
     for (unsigned int iter(0); iter < (sizeof(modifiers) / sizeof(modifiers[0])); ++iter) {
         mod_map.append(modifiers[iter].second);
+        mod_map.append('\0');
     }
     return mod_map;
 }


### PR DESCRIPTION
Fix the modifiers map by using the nul character as separator.
Handle additional keysyms which may come from virtual keyboards.