### PR TITLE
Re-show the keyboard on wayland surrounding text changes

### DIFF
--- a/connection/waylandinputmethodconnection.cpp
+++ b/connection/waylandinputmethodconnection.cpp
@@ -591,6 +591,9 @@ void InputMethodContext::zwp_input_method_context_v1_surrounding_text(const QStr
 {
     qCDebug(lcWaylandConnection) << Q_FUNC_INFO;
 
+    // Re-show the keyboard if it was hidden without changing focus.
+    m_connection->showInputMethod(wayland_connection_id);
+
     const QByteArray &utf8_text(text.toUtf8());
 
     m_stateInfo[SurroundingTextAttribute] = text;


### PR DESCRIPTION
If we the keyboard is hidden (using the close gesture or a similar
method) and the surrounding text changes (suggesting the user tapped the
same text field but in a different place), re-show the keyboard.

This assumes the user hid the keyboard manually, then tapped the
textfield again to request it be reshown.