### PR TITLE
Fix maliit-defines.prf paths

### DIFF
--- a/src/maliit-defines.prf.in
+++ b/src/maliit-defines.prf.in
@@ -2,6 +2,6 @@
 # It is made separated, so one can load it eagerly with load() function
 # without risk to affect building part.
 MALIIT_PREFIX=@CMAKE_INSTALL_PREFIX@
-MALIIT_PLUGINS_DIR = @CMAKE_INSTALL_LIBDIR@/maliit/plugins
-MALIIT_PLUGINS_DATA_DIR = @CMAKE_INSTALL_DATADIR@/maliit/plugins
-MALIIT_INSTALL_LIBS = @CMAKE_INSTALL_LIBDIR@
+MALIIT_PLUGINS_DIR = @CMAKE_INSTALL_FULL_LIBDIR@/maliit/plugins
+MALIIT_PLUGINS_DATA_DIR = @CMAKE_INSTALL_FULL_DATADIR@/maliit/plugins
+MALIIT_INSTALL_LIBS = @CMAKE_INSTALL_FULL_LIBDIR@


### PR DESCRIPTION
Before the cmake switch these were all full paths.