### PR TITLE
InputMethodQuick: Expose surface as a protected method for plugins

### DIFF
--- a/src/quick/inputmethodquick.cpp
+++ b/src/quick/inputmethodquick.cpp
@@ -640,4 +640,10 @@ bool InputMethodQuick::hiddenText()
     return d->m_hiddenText;
 }
 
+const QQuickView* InputMethodQuick::surface()
+{
+    Q_D(InputMethodQuick);
+    return d->surface.data();
+}
+
 } // namespace Maliit

--- a/src/quick/inputmethodquick.h
+++ b/src/quick/inputmethodquick.h
@@ -24,6 +24,8 @@
 #include <QScopedPointer>
 #include <QString>
 
+#include <QQuickView>
+
 namespace Maliit
 {
 
@@ -211,6 +213,10 @@ public Q_SLOTS:
 
     //! Tells the framework to close keyboard. Called by QML components.
     void userHide();
+
+protected:
+    //! Returns the QQuickView of the plugin, so derivatives may access it.
+    const QQuickView* surface();
 
 private:
     Q_DISABLE_COPY(InputMethodQuick)


### PR DESCRIPTION
So that plugins inheriting from InputMethodQuick can access the surface
their content is rendered on, provide a protected method which returns
a const QQuickView object from the internal QScopedPointer.