### PR TITLE
WindowGroup: Add the Mir input panel window type flag

### DIFF
--- a/src/windowgroup.cpp
+++ b/src/windowgroup.cpp
@@ -64,7 +64,12 @@ void WindowGroup::setupWindow(QWindow *window, Maliit::Position position)
             window->setFlags(Qt::Window
                              | Qt::FramelessWindowHint
                              | Qt::WindowStaysOnTopHint
-                             | Qt::WindowDoesNotAcceptFocus);
+                             | Qt::WindowDoesNotAcceptFocus
+                             /* Mir uses a special window type for input method
+                              * panel, which is not handled by Qt::WindowType
+                              * natively, so add the magic value here
+                              */
+                             | static_cast<Qt::WindowType>(0x00000080));
 
             connect (window, SIGNAL (visibleChanged(bool)),
                      this, SLOT (onVisibleChanged(bool)));


### PR DESCRIPTION
As Mir has a special window type for input method panel, set the magic
number in the window type flags when setting up the window, to enable
plugins working correctly where Mir is used.