### PR TITLE
Use QLoggingCategories for logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,8 @@ set(PLUGINS_SOURCES
     src/quick/maliitquick.h
     src/abstractplatform.cpp
     src/abstractplatform.h
+    src/logging.cpp
+    src/logging.h
     src/mattributeextensionid.cpp
     src/mattributeextensionid.h
     src/mattributeextensionmanager.cpp

--- a/connection/dbusinputcontextconnection.cpp
+++ b/connection/dbusinputcontextconnection.cpp
@@ -254,7 +254,6 @@ DBusInputContextConnection::sendActivationLostEvent()
 void
 DBusInputContextConnection::updateInputMethodArea(const QRegion &region)
 {
-    qDebug() << "Updating input method area to" << region;
     ComMeegoInputmethodInputcontext1Interface *proxy = mProxys.value(activeConnection);
     if (proxy) {
         QRect rect = region.boundingRect();

--- a/input-context/minputcontext.h
+++ b/input-context/minputcontext.h
@@ -129,8 +129,6 @@ private:
     // Parameter valid set to false on failure.
     int cursorStartPosition(bool *valid);
 
-    static bool debug;
-
     DBusServerConnection *imServer;
     bool active; // is connection active
     QPointer<QWindow> window;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -1,0 +1,16 @@
+/* * This file is part of Maliit framework *
+ *
+ * Copyright (C) 2022 Pekka Vuorela
+ * All rights reserved.
+ *
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1 as published by the Free Software Foundation
+ * and appearing in the file LICENSE.LGPL included in the packaging
+ * of this file.
+ */
+
+#include "logging.h"
+
+Q_LOGGING_CATEGORY(lcMaliitFw, "org.maliit.framework", QtWarningMsg)

--- a/src/logging.h
+++ b/src/logging.h
@@ -1,0 +1,16 @@
+/* * This file is part of Maliit framework *
+ *
+ * Copyright (C) 2022 Pekka Vuorela
+ * All rights reserved.
+ *
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1 as published by the Free Software Foundation
+ * and appearing in the file LICENSE.LGPL included in the packaging
+ * of this file.
+ */
+
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(lcMaliitFw)

--- a/src/mattributeextensionmanager.cpp
+++ b/src/mattributeextensionmanager.cpp
@@ -13,6 +13,7 @@
 
 
 #include "mattributeextensionmanager.h"
+#include "logging.h"
 #include <maliit/plugins/keyoverridedata.h>
 #include <maliit/plugins/keyoverride.h>
 
@@ -160,7 +161,7 @@ void MAttributeExtensionManager::setExtendedAttribute(const MAttributeExtensionI
     QSharedPointer<MAttributeExtension> extension = attributeExtension(id);
 
     if (!extension) {
-        qWarning() << "Extended attribute change with invalid id";
+        qCWarning(lcMaliitFw) << "Extended attribute change with invalid id";
         return;
     }
 
@@ -188,7 +189,7 @@ void MAttributeExtensionManager::setExtendedAttribute(const MAttributeExtensionI
             Q_EMIT keyOverrideCreated();
         }
     } else {
-        qWarning() << "Invalid or incompatible attribute extension target:" << target;
+        qCWarning(lcMaliitFw) << "Invalid or incompatible attribute extension target:" << target;
     }
 }
 
@@ -260,7 +261,7 @@ void MAttributeExtensionManager::handleWidgetStateChanged(unsigned int clientId,
 
     variant = newState[FocusStateAttribute];
     if (not variant.isValid()) {
-        qCritical() << __PRETTY_FUNCTION__ << "Invalid focus state";
+        qCCritical(lcMaliitFw) << Q_FUNC_INFO << "Invalid focus state";
     }
     bool widgetFocusState = variant.toBool();
 
@@ -273,7 +274,7 @@ void MAttributeExtensionManager::handleWidgetStateChanged(unsigned int clientId,
             // if im-uiserver crashes.
             // XXX: should not happen, the input context is reponsible for registering
             // and resending the toolbar information on server reconnect
-            qWarning() << "Unregistered toolbar found in widget information";
+            qCWarning(lcMaliitFw) << "Unregistered toolbar found in widget information";
 
             variant = newState[ToolbarIdAttribute];
             if (variant.isValid()) {

--- a/src/mimserver.cpp
+++ b/src/mimserver.cpp
@@ -15,6 +15,7 @@
 
 #include "mimpluginmanager.h"
 #include "mimsettings.h"
+#include "logging.h"
 
 class MImServerPrivate
 {
@@ -63,7 +64,6 @@ void MImServer::configureSettings(MImServer::SettingsType settingsType)
         break;
 
     default:
-        qCritical() << __PRETTY_FUNCTION__ <<
-                       "Invalid value for preferredSettingType." << settingsType;
+        qCCritical(lcMaliitFw) << Q_FUNC_INFO << "Invalid value for preferredSettingType." << settingsType;
     }
 }

--- a/src/mimsettings.cpp
+++ b/src/mimsettings.cpp
@@ -13,6 +13,7 @@
 
 #include "mimsettings.h"
 #include "mimsettingsqsettings.h"
+#include "logging.h"
 
 #include <QString>
 #include <QStringList>
@@ -101,8 +102,7 @@ MImSettings::MImSettings(const QString &key, QObject *parent)
             break;
 
         default:
-            qCritical() << __PRETTY_FUNCTION__ <<
-                           "Invalid value for preferredSettingType." << preferredSettingsType;
+            qCCritical(lcMaliitFw) << Q_FUNC_INFO << "Invalid value for preferredSettingType." << preferredSettingsType;
         }
         MImSettings::setImplementationFactory(newFactory);
     }

--- a/src/quick/inputmethodquick.cpp
+++ b/src/quick/inputmethodquick.cpp
@@ -15,6 +15,7 @@
 
 #include "keyoverridequick.h"
 #include "maliitquick.h"
+#include "logging.h"
 
 #include <maliit/plugins/abstractinputmethodhost.h>
 #include <maliit/plugins/keyoverride.h>
@@ -457,7 +458,7 @@ void InputMethodQuick::sendPreedit(const QString &text,
             int length = 0;
 
             if (formatTuple.length() < 3) {
-                qWarning() << "MInputMethodQuick.sendPreedit() got formatting tuple with less than three parameters";
+                qCWarning(lcMaliitFw) << "MInputMethodQuick.sendPreedit() got formatting tuple with less than three parameters";
                 continue;
             }
 

--- a/src/quick/keyoverridequick.cpp
+++ b/src/quick/keyoverridequick.cpp
@@ -14,6 +14,7 @@
 #include <QDebug>
 #include <QtAlgorithms>
 
+#include "logging.h"
 #include "keyoverridequick.h"
 #include "keyoverridequick_p.h"
 
@@ -280,7 +281,7 @@ void KeyOverrideQuick::applyOverride(const QSharedPointer<MKeyOverride>& keyOver
         } else if (not d->defaultLabel.isEmpty()) {
             labelAction = UseDefault;
         } else {
-            qCritical() << __PRETTY_FUNCTION__ << "- Both label and icon have no default value.";
+            qCCritical(lcMaliitFw) << Q_FUNC_INFO << "- Both label and icon have no default value.";
         }
 
         if (changedAttributes & MKeyOverride::Highlighted) {
@@ -326,7 +327,7 @@ void KeyOverrideQuick::applyOverride(const QSharedPointer<MKeyOverride>& keyOver
     case UseActual:
         break;
     default:
-        qCritical() << __PRETTY_FUNCTION__ << "- unknown enum value for iconAction:" << static_cast<int> (iconAction);
+        qCCritical(lcMaliitFw) << Q_FUNC_INFO << "- unknown enum value for iconAction:" << static_cast<int> (iconAction);
     }
 
     switch (labelAction) {
@@ -342,7 +343,7 @@ void KeyOverrideQuick::applyOverride(const QSharedPointer<MKeyOverride>& keyOver
     case UseActual:
         break;
     default:
-        qCritical() << __PRETTY_FUNCTION__ << "- unknown enum value for labelAction:" << static_cast<int> (labelAction);
+        qCCritical(lcMaliitFw) << Q_FUNC_INFO << "- unknown enum value for labelAction:" << static_cast<int> (labelAction);
     }
 }
 

--- a/src/windowgroup.cpp
+++ b/src/windowgroup.cpp
@@ -14,6 +14,7 @@
 
 #include "abstractplatform.h"
 #include "windowgroup.h"
+#include "logging.h"
 
 namespace Maliit
 {
@@ -56,7 +57,7 @@ void WindowGroup::setupWindow(QWindow *window, Maliit::Position position)
             QWindow *parent = window->parent ();
 
             if (parent and not containsWindow(parent)) {
-                qWarning () << "Plugin is misbehaving - tried to register a window with yet-unregistered parent!";
+                qCWarning(lcMaliitFw) << "Plugin is misbehaving - tried to register a window with yet-unregistered parent!";
                 return;
             }
             m_window_list.append (WindowData(window, position));
@@ -127,7 +128,7 @@ void WindowGroup::onVisibleChanged(bool visible)
         QWindow *window = qobject_cast<QWindow*>(sender());
 
         if (window) {
-            qWarning () << "An inactive plugin is misbehaving - tried to show a window!";
+            qCWarning(lcMaliitFw) << "An inactive plugin is misbehaving - tried to show a window!";
             window->setVisible (false);
         }
     }

--- a/src/xcbplatform.cpp
+++ b/src/xcbplatform.cpp
@@ -21,6 +21,7 @@
 #include <qpa/qplatformnativeinterface.h>
 
 #include "xcbplatform.h"
+#include "logging.h"
 
 namespace Maliit
 {
@@ -39,7 +40,7 @@ void XCBPlatform::setupInputPanel(QWindow* window,
     xcb_connection_t *xcbConnection
             = static_cast<xcb_connection_t *>(xcbiface->nativeResourceForWindow("connection", window));
     if (!xcbConnection) {
-        qWarning("Unable to get Xcb connection");
+        qCWarning(lcMaliitFw) << "Unable to get Xcb connection";
         return;
     }
 
@@ -59,7 +60,7 @@ void XCBPlatform::setupInputPanel(QWindow* window,
         windowTypeAtom = reply->atom;
         free(reply);
     } else {
-        qWarning("Unable to fetch window type atom");
+        qCWarning(lcMaliitFw) << "Unable to fetch window type atom";
         return;
     }
 
@@ -68,7 +69,7 @@ void XCBPlatform::setupInputPanel(QWindow* window,
         windowTypeInputAtom = reply->atom;
         free(reply);
     } else {
-        qWarning("Unable to fetch window type input atom");
+        qCWarning(lcMaliitFw) << "Unable to fetch window type input atom";
         return;
     }
 
@@ -113,8 +114,8 @@ void XCBPlatform::setInputRegion(QWindow* window,
 
 void XCBPlatform::setApplicationWindow(QWindow *window, WId appWindowId)
 {
-    qDebug() << "Xcb platform setting transient target" << QString("0x%1").arg(QString::number(appWindowId, 16))
-             << "for" << QString("0x%1").arg(QString::number(window->winId(), 16));
+    qCDebug(lcMaliitFw) << "Xcb platform setting transient target" << QString("0x%1").arg(QString::number(appWindowId, 16))
+                        << "for" << QString("0x%1").arg(QString::number(window->winId(), 16));
 
     QPlatformNativeInterface *xcbiface = QGuiApplication::platformNativeInterface();
     xcb_connection_t *xcbConnection

--- a/tests/dummyimplugin/dummyinputmethod.cpp
+++ b/tests/dummyimplugin/dummyinputmethod.cpp
@@ -35,7 +35,7 @@ DummyInputMethod::DummyInputMethod(MAbstractInputMethodHost *host)
 
 void DummyInputMethod::setState(const QSet<Maliit::HandlerState> &state)
 {
-    qDebug() << __PRETTY_FUNCTION__ << state;
+    qDebug() << Q_FUNC_INFO << state;
     ++setStateCount;
     setStateParam = state;
 
@@ -44,13 +44,13 @@ void DummyInputMethod::setState(const QSet<Maliit::HandlerState> &state)
 
 void DummyInputMethod::switchMe()
 {
-    qDebug() << __PRETTY_FUNCTION__;
+    qDebug() << Q_FUNC_INFO;
     inputMethodHost()->switchPlugin(Maliit::SwitchForward);
 }
 
 void DummyInputMethod::switchMe(const QString &name)
 {
-    qDebug() << __PRETTY_FUNCTION__;
+    qDebug() << Q_FUNC_INFO;
     inputMethodHost()->switchPlugin(name);
 }
 
@@ -69,7 +69,7 @@ void DummyInputMethod::switchContext(Maliit::SwitchDirection direction, bool ena
 QList<MAbstractInputMethod::MInputMethodSubView>
 DummyInputMethod::subViews(Maliit::HandlerState state) const
 {
-    qDebug() << __PRETTY_FUNCTION__;
+    qDebug() << Q_FUNC_INFO;
     QList<MAbstractInputMethod::MInputMethodSubView> svs;
     if (state == Maliit::OnScreen) {
         svs = sViews;
@@ -79,7 +79,7 @@ DummyInputMethod::subViews(Maliit::HandlerState state) const
 
 void DummyInputMethod::setActiveSubView(const QString &sVId, Maliit::HandlerState state)
 {
-    qDebug() << __PRETTY_FUNCTION__;
+    qDebug() << Q_FUNC_INFO;
     if (state == Maliit::OnScreen) {
         Q_FOREACH (const MAbstractInputMethod::MInputMethodSubView &sv, sViews) {
             if (sv.subViewId == sVId) {
@@ -91,7 +91,7 @@ void DummyInputMethod::setActiveSubView(const QString &sVId, Maliit::HandlerStat
 
 QString DummyInputMethod::activeSubView(Maliit::HandlerState state) const
 {
-    qDebug() << __PRETTY_FUNCTION__;
+    qDebug() << Q_FUNC_INFO;
     if (state == Maliit::OnScreen)
         return activeSView;
     else

--- a/tests/dummyimplugin3/dummyinputmethod3.cpp
+++ b/tests/dummyimplugin3/dummyinputmethod3.cpp
@@ -41,7 +41,7 @@ DummyInputMethod3::DummyInputMethod3(MAbstractInputMethodHost *host)
 
 void DummyInputMethod3::setState(const QSet<Maliit::HandlerState> &state)
 {
-    qDebug() << __PRETTY_FUNCTION__ << state;
+    qDebug() << Q_FUNC_INFO << state;
     ++setStateCount;
     setStateParam = state;
 }
@@ -57,7 +57,7 @@ void DummyInputMethod3::switchContext(Maliit::SwitchDirection direction,
 QList<MAbstractInputMethod::MInputMethodSubView>
 DummyInputMethod3::subViews(Maliit::HandlerState state) const
 {
-    qDebug() << __PRETTY_FUNCTION__;
+    qDebug() << Q_FUNC_INFO;
     QList<MAbstractInputMethod::MInputMethodSubView> svs;
     if (state == Maliit::OnScreen) {
         svs = sViews;
@@ -67,7 +67,7 @@ DummyInputMethod3::subViews(Maliit::HandlerState state) const
 
 void DummyInputMethod3::setActiveSubView(const QString &sVId, Maliit::HandlerState state)
 {
-    qDebug() << __PRETTY_FUNCTION__;
+    qDebug() << Q_FUNC_INFO;
     if (state == Maliit::OnScreen) {
         Q_FOREACH (const MAbstractInputMethod::MInputMethodSubView &sv, sViews) {
             if (sv.subViewId == sVId) {
@@ -79,7 +79,7 @@ void DummyInputMethod3::setActiveSubView(const QString &sVId, Maliit::HandlerSta
 
 QString DummyInputMethod3::activeSubView(Maliit::HandlerState state) const
 {
-    qDebug() << __PRETTY_FUNCTION__;
+    qDebug() << Q_FUNC_INFO;
     if (state == Maliit::OnScreen)
         return activeSView;
     else


### PR DESCRIPTION
More standard logging, allows better control on what gets printed and avoids collision with QT_MESSAGE_PATTERN, etc. Also console.log() etc will not be filtered out by default which to me has appeared to confuse some people trying to hack the keyboard before finding out the environment variable.
