### PR TITLE
Fix application orientation angle back to clockwise

### DIFF
--- a/input-context/minputcontext.cpp
+++ b/input-context/minputcontext.cpp
@@ -50,7 +50,7 @@ namespace
     int orientationAngle(Qt::ScreenOrientation orientation)
     {
         QScreen *screen = qGuiApp->primaryScreen();
-        return screen->angleBetween(screen->primaryOrientation(), orientation);
+        return screen->angleBetween(orientation, screen->primaryOrientation());
     }
 }
 

--- a/src/maliit/plugins/abstractinputmethod.h
+++ b/src/maliit/plugins/abstractinputmethod.h
@@ -138,13 +138,13 @@ public:
      * Note that this method might not be called when the input method shown for the first time.
      * \sa handleAppOrientationChanged(int angle)
      *
-     * \param angle The angle in degrees. Possible values: 0, 90, 180, 270. 0 is the normal orientation of the display server.
+     * \param angle The angle in degrees, clockwise. Possible values: 0, 90, 180, 270. 0 is the normal orientation of the display server.
      */
     virtual void handleAppOrientationAboutToChange(int angle);
 
     /*! \brief Target application already finish changing orientation.
      *
-     * \param angle The angle in degrees. Possible values: 0, 90, 180, 270. 0 is the normal orientation of the display server.
+     * \param angle The angle in degrees, clockwise. Possible values: 0, 90, 180, 270. 0 is the normal orientation of the display server.
      */
     virtual void handleAppOrientationChanged(int angle);
 


### PR DESCRIPTION
Got changed in commit b9f448fcc

Slightly hard to follow, but the Qt::LandscapeOrientation & friends
are defined with clockwise orientation. The QScreen::angleBetween()
doesn't explicitly define the direction but the results match how much
the physical screen would need to be rotated clockwise, and commonly
clockwise angles are used within Qt.

But now, if the display is rotated 90 degrees clockwise, the application
UI should be rotated to opposite direction to remain shown correctly,
i.e. to 270.

Thus switch the parameter order to angleBetween() and define the resulting
appOrientation angle to hopefully avoid confusion in the future.

---
Took a peek at the maliit-keyboard side too and looks like src/plugin/inputmethod.cpp / rotationAngleToScreenOrientation() is indeed assuming either device (not app) orientation angle, or alternative assuming counter-clockwise angles. But then again the value is stored in maliit_geometry.orientation and I'm not spotting any use for it. Seems dead code(?) In addition there's InputMethod::deviceOrientationChanged() that was earlier having some workaround and bypassing the application reported orientation but now seems dead as well.