### PR TITLE
ut_mimserveroptions: Move the operator== definition to global namespace

### DIFF
--- a/tests/ut_mimserveroptions/ut_mimserveroptions.cpp
+++ b/tests/ut_mimserveroptions/ut_mimserveroptions.cpp
@@ -42,12 +42,12 @@ namespace {
                           "-testability", "TESTABILITY", "-qdevel", "-reverse",
                           "-stylesheet", "-widgetcount", "-qdebug",
                           "-software" } };
+}
 
-    bool operator==(const MImServerCommonOptions &x,
-                    const MImServerCommonOptions &y)
-    {
-        return (x.showHelp == y.showHelp);
-    }
+bool operator==(const MImServerCommonOptions &x,
+                const MImServerCommonOptions &y)
+{
+    return (x.showHelp == y.showHelp);
 }
 
 


### PR DESCRIPTION
With gcc-12 having the operator== in anonymous namespace for a struct which
is in the global namespace results in a lengthy compilation error. Moving
this non-mmember function into the global namespace fixes the issue.

Fixes #112