### PR TITLE
Prevent QList returned by subject->pluginDescriptions from being deleted

### DIFF
--- a/tests/ft_mimpluginmanager/ft_mimpluginmanager.cpp
+++ b/tests/ft_mimpluginmanager/ft_mimpluginmanager.cpp
@@ -202,16 +202,19 @@ void Ft_MIMPluginManager::testPluginDescriptions()
 
     MImSettings enabledPluginsSettings(EnabledPluginsKey);
     QStringList enabledPlugins;
+
+    QList<MImPluginDescription> pluginDescriptions;
     const MImPluginDescription *description = 0;
 
     enabledPlugins << pluginId + ":" + "dummyimsv1";
     enabledPluginsSettings.set(enabledPlugins);
     QCOMPARE(spy.count(), 1);
 
-    description = findPluginDescriptions(subject->pluginDescriptions(Maliit::OnScreen), pluginName);
+    pluginDescriptions = subject->pluginDescriptions(Maliit::OnScreen);
+    description = findPluginDescriptions(pluginDescriptions, pluginName);
     QVERIFY(description);
     QVERIFY(description->enabled());
-    description = findPluginDescriptions(subject->pluginDescriptions(Maliit::OnScreen), pluginName3);
+    description = findPluginDescriptions(pluginDescriptions, pluginName3);
     QVERIFY(description);
     QVERIFY(!description->enabled());
     description = 0;
@@ -220,10 +223,11 @@ void Ft_MIMPluginManager::testPluginDescriptions()
     enabledPluginsSettings.set(enabledPlugins);
     QCOMPARE(spy.count(), 2);
 
-    description = findPluginDescriptions(subject->pluginDescriptions(Maliit::OnScreen), pluginName);
+    pluginDescriptions = subject->pluginDescriptions(Maliit::OnScreen);
+    description = findPluginDescriptions(pluginDescriptions, pluginName);
     QVERIFY(description);
     QVERIFY(description->enabled());
-    description = findPluginDescriptions(subject->pluginDescriptions(Maliit::OnScreen), pluginName3);
+    description = findPluginDescriptions(pluginDescriptions, pluginName3);
     QVERIFY(description);
     QVERIFY(!description->enabled());
     description = 0;
@@ -232,10 +236,11 @@ void Ft_MIMPluginManager::testPluginDescriptions()
     enabledPluginsSettings.set(enabledPlugins);
     QCOMPARE(spy.count(), 3);
 
-    description = findPluginDescriptions(subject->pluginDescriptions(Maliit::OnScreen), pluginName);
+    pluginDescriptions = subject->pluginDescriptions(Maliit::OnScreen);
+    description = findPluginDescriptions(pluginDescriptions, pluginName);
     QVERIFY(description);
     QVERIFY(description->enabled());
-    description = findPluginDescriptions(subject->pluginDescriptions(Maliit::OnScreen), pluginName3);
+    description = findPluginDescriptions(pluginDescriptions, pluginName3);
     QVERIFY(description);
     QVERIFY(description->enabled());
     description = 0;


### PR DESCRIPTION
If we don't save QList to a variable, it becomes deleted, and pointer returned by findPluginDescriptions becomes invalid. Then trying to call description->enabled() results in a segmentation fault.

Here is valgrind report:

```
==17249== Invalid read of size 8
==17249==    at 0x49D0EB0: MImPluginDescription::enabled() const (plugindescription.cpp:72)
==17249==    by 0x12BB69: Ft_MIMPluginManager::testPluginDescriptions() (ft_mimpluginmanager.cpp:213)
==17249==    by 0x53D17BD: QMetaMethod::invoke(QObject*, Qt::ConnectionType, QGenericReturnArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument) const (qmetaobject.cpp:2303)
==17249==    by 0x489FBD0: invoke (qmetaobject.h:122)
==17249==    by 0x489FBD0: QTest::TestMethods::invokeTestOnData(int) const (qtestcase.cpp:938)
==17249==    by 0x48A063E: QTest::TestMethods::invokeTest(int, char const*, QTest::WatchDog*) const (qtestcase.cpp:1166)
==17249==    by 0x48A0BD8: QTest::TestMethods::invokeTests(QObject*) const (qtestcase.cpp:1507)
==17249==    by 0x48A10C1: QTest::qRun() (qtestcase.cpp:1934)
==17249==    by 0x48A146A: QTest::qExec(QObject*, int, char**) (qtestcase.cpp:1842)
==17249==    by 0x1287DA: main (ft_mimpluginmanager.cpp:335)
==17249==  Address 0x9c31fd8 is 8 bytes inside a block of size 16 free'd
==17249==    at 0x484399B: operator delete(void*, unsigned long) (vg_replace_malloc.c:935)
==17249==    by 0x12E9E2: node_destruct (qlist.h:524)
==17249==    by 0x12E9E2: dealloc (qlist.h:921)
==17249==    by 0x12E9E2: ~QList (qlist.h:874)
==17249==    by 0x12E9E2: QList<MImPluginDescription>::~QList() (qlist.h:871)
==17249==    by 0x12BABC: Ft_MIMPluginManager::testPluginDescriptions() (ft_mimpluginmanager.cpp:211)
==17249==    by 0x53D17BD: QMetaMethod::invoke(QObject*, Qt::ConnectionType, QGenericReturnArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument) const (qmetaobject.cpp:2303)
==17249==    by 0x489FBD0: invoke (qmetaobject.h:122)
==17249==    by 0x489FBD0: QTest::TestMethods::invokeTestOnData(int) const (qtestcase.cpp:938)
==17249==    by 0x48A063E: QTest::TestMethods::invokeTest(int, char const*, QTest::WatchDog*) const (qtestcase.cpp:1166)
==17249==    by 0x48A0BD8: QTest::TestMethods::invokeTests(QObject*) const (qtestcase.cpp:1507)
==17249==    by 0x48A10C1: QTest::qRun() (qtestcase.cpp:1934)
==17249==    by 0x48A146A: QTest::qExec(QObject*, int, char**) (qtestcase.cpp:1842)
==17249==    by 0x1287DA: main (ft_mimpluginmanager.cpp:335)
==17249==  Block was alloc'd at
==17249==    at 0x4840F2F: operator new(unsigned long) (vg_replace_malloc.c:422)
==17249==    by 0x49ED895: node_construct (qlist.h:465)
==17249==    by 0x49ED895: QList<MImPluginDescription>::append(MImPluginDescription const&) (qlist.h:625)
==17249==    by 0x49EC7FE: MIMPluginManagerPrivate::pluginDescriptions(Maliit::HandlerState) const (mimpluginmanager.cpp:644)
==17249==    by 0x49EC900: MIMPluginManager::pluginDescriptions(Maliit::HandlerState) const (mimpluginmanager.cpp:1244)
==17249==    by 0x12BAA0: Ft_MIMPluginManager::testPluginDescriptions() (ft_mimpluginmanager.cpp:211)
==17249==    by 0x53D17BD: QMetaMethod::invoke(QObject*, Qt::ConnectionType, QGenericReturnArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument) const (qmetaobject.cpp:2303)
==17249==    by 0x489FBD0: invoke (qmetaobject.h:122)
==17249==    by 0x489FBD0: QTest::TestMethods::invokeTestOnData(int) const (qtestcase.cpp:938)
==17249==    by 0x48A063E: QTest::TestMethods::invokeTest(int, char const*, QTest::WatchDog*) const (qtestcase.cpp:1166)
==17249==    by 0x48A0BD8: QTest::TestMethods::invokeTests(QObject*) const (qtestcase.cpp:1507)
==17249==    by 0x48A10C1: QTest::qRun() (qtestcase.cpp:1934)
==17249==    by 0x48A146A: QTest::qExec(QObject*, int, char**) (qtestcase.cpp:1842)
==17249==    by 0x1287DA: main (ft_mimpluginmanager.cpp:335)
```