### PR TITLE
connection: Move dbus socket to well known path in XDG_RUNTIME_DIR

### DIFF
--- a/connection/serverdbusaddress.cpp
+++ b/connection/serverdbusaddress.cpp
@@ -15,8 +15,8 @@
 
 #include <QDebug>
 #include <QDBusConnection>
-
 #include <QDBusServer>
+#include <QStandardPaths>
 
 #include <cstdlib>
 
@@ -61,7 +61,8 @@ DynamicAddress::DynamicAddress()
 
 QDBusServer* DynamicAddress::connect()
 {
-    QLatin1String dbusAddress("unix:tmpdir=/tmp/maliit-server");
+    auto runtimeDir = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
+    auto dbusAddress = QLatin1String("unix:path=%1/maliit-server").arg(runtimeDir);
 
     QDBusServer *server = new QDBusServer(dbusAddress);
 


### PR DESCRIPTION
As dbus has now changed to make tmpdir behave the same as dir, socket creation fails when the directory does not exist, and it is no longer automatically removed upon exit. Instead, switch to a well known name under XDG_RUNTIME_DIR, as only one instance of the dbus service can exist at a time, per user.